### PR TITLE
Add compatibility with env_logger 0.5

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ use std::path::PathBuf;
 use std::process;
 
 pub fn run() {
-    env_logger::init().unwrap();
+    drop(env_logger::init());
     let result = rustc_driver::run(|| {
         let args = env::args_os().enumerate()
             .map(|(i, arg)| arg.into_string().unwrap_or_else(|arg| {


### PR DESCRIPTION
Gonna try to update in rust-lang/rust and this fixes a build error